### PR TITLE
ごみ検索の流れ（DBから検索はしない）

### DIFF
--- a/iidaPro-2015.xcodeproj/project.pbxproj
+++ b/iidaPro-2015.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		998992931B33B6A5000B7FD2 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 998992921B33B6A5000B7FD2 /* Images.xcassets */; };
 		998992961B33B6A5000B7FD2 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 998992941B33B6A5000B7FD2 /* LaunchScreen.xib */; };
 		998992A21B33B6A5000B7FD2 /* iidaPro_2015Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 998992A11B33B6A5000B7FD2 /* iidaPro_2015Tests.m */; };
+		99FDB35B1B79BA5D00DB12E3 /* SearchResultViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 99FDB35A1B79BA5D00DB12E3 /* SearchResultViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,8 @@
 		9989929B1B33B6A5000B7FD2 /* iidaPro-2015Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iidaPro-2015Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		998992A01B33B6A5000B7FD2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		998992A11B33B6A5000B7FD2 /* iidaPro_2015Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iidaPro_2015Tests.m; sourceTree = "<group>"; };
+		99FDB3591B79BA5D00DB12E3 /* SearchResultViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SearchResultViewController.h; sourceTree = "<group>"; };
+		99FDB35A1B79BA5D00DB12E3 /* SearchResultViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SearchResultViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +128,8 @@
 				9989928A1B33B6A5000B7FD2 /* AppDelegate.m */,
 				9989928C1B33B6A5000B7FD2 /* ViewController.h */,
 				9989928D1B33B6A5000B7FD2 /* ViewController.m */,
+				99FDB3591B79BA5D00DB12E3 /* SearchResultViewController.h */,
+				99FDB35A1B79BA5D00DB12E3 /* SearchResultViewController.m */,
 				8B18F1851B467B5A0060BF02 /* Main.storyboard */,
 				998992921B33B6A5000B7FD2 /* Images.xcassets */,
 				998992941B33B6A5000B7FD2 /* LaunchScreen.xib */,
@@ -264,6 +269,7 @@
 				8B9387861B4DF37E004E70E2 /* TipsViewController.m in Sources */,
 				9989928E1B33B6A5000B7FD2 /* ViewController.m in Sources */,
 				8B88A87D1B4C949E000D970B /* TipsCustomTableCell.m in Sources */,
+				99FDB35B1B79BA5D00DB12E3 /* SearchResultViewController.m in Sources */,
 				8B3E08DC1B4E5EE1001EE9B4 /* SecondTipsViewController.m in Sources */,
 				9989928B1B33B6A5000B7FD2 /* AppDelegate.m in Sources */,
 				8B88A8851B4C9FFE000D970B /* TipsNextViewController.m in Sources */,

--- a/iidaPro-2015/Main.storyboard
+++ b/iidaPro-2015/Main.storyboard
@@ -39,6 +39,43 @@
             </objects>
             <point key="canvasLocation" x="1227" y="224"/>
         </scene>
+        <!--Search Result View Controller-->
+        <scene sceneID="pI3-BP-ugR">
+            <objects>
+                <viewController storyboardIdentifier="Search" id="Ecc-V6-wdr" customClass="SearchResultViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="mYh-N8-UBj"/>
+                        <viewControllerLayoutGuide type="bottom" id="fYy-so-LVZ"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="iRq-3Y-csp">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="EAn-PY-EQu">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="Ecc-V6-wdr" id="wAG-Tq-HNH"/>
+                                    <outlet property="delegate" destination="Ecc-V6-wdr" id="mdJ-tv-cIL"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="EAn-PY-EQu" firstAttribute="bottom" secondItem="fYy-so-LVZ" secondAttribute="top" id="AC6-5k-LqU"/>
+                            <constraint firstItem="EAn-PY-EQu" firstAttribute="leading" secondItem="iRq-3Y-csp" secondAttribute="leading" id="IeT-Jg-pjF"/>
+                            <constraint firstAttribute="trailing" secondItem="EAn-PY-EQu" secondAttribute="trailing" id="SwP-LF-nHw"/>
+                            <constraint firstItem="EAn-PY-EQu" firstAttribute="top" secondItem="iRq-3Y-csp" secondAttribute="top" id="Tms-qt-mns"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="searchTableView" destination="EAn-PY-EQu" id="jTB-WY-85M"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="HaF-kv-4IJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1227" y="928"/>
+        </scene>
         <!--ごみの出し方-->
         <scene sceneID="d2g-xc-CEK">
             <objects>

--- a/iidaPro-2015/Main.storyboard
+++ b/iidaPro-2015/Main.storyboard
@@ -32,37 +32,10 @@
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <searchBar contentMode="redraw" backgroundImage="empty" translatesAutoresizingMaskIntoConstraints="NO" id="SVX-N1-dvH">
-                                <rect key="frame" x="0.0" y="20" width="600" height="44"/>
-                                <textInputTraits key="textInputTraits"/>
-                                <connections>
-                                    <outlet property="delegate" destination="vXZ-lx-hvc" id="xjv-eK-3Mc"/>
-                                </connections>
-                            </searchBar>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="SVX-N1-dvH" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" constant="20" id="1od-MY-1Ng"/>
-                            <constraint firstItem="SVX-N1-dvH" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="fkV-yE-DU6"/>
-                            <constraint firstAttribute="trailing" secondItem="SVX-N1-dvH" secondAttribute="trailing" id="vlI-h3-r1f"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="8HQ-61-3kr"/>
-                    <connections>
-                        <outlet property="searchBar" destination="SVX-N1-dvH" id="rva-RE-ntA"/>
-                        <outlet property="searchDisplayController" destination="3n8-b6-vdZ" id="kSu-dw-biO"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="3n8-b6-vdZ">
-                    <connections>
-                        <outlet property="delegate" destination="vXZ-lx-hvc" id="dyw-vh-ELv"/>
-                        <outlet property="searchBar" destination="SVX-N1-dvH" id="jEk-qh-pl5"/>
-                        <outlet property="searchContentsController" destination="vXZ-lx-hvc" id="2oE-No-9Uz"/>
-                        <outlet property="searchResultsDataSource" destination="vXZ-lx-hvc" id="Dev-oP-wVb"/>
-                        <outlet property="searchResultsDelegate" destination="vXZ-lx-hvc" id="pL2-tD-hGD"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="1227" y="224"/>
         </scene>
@@ -335,9 +308,6 @@
             <point key="canvasLocation" x="3434" y="151"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="empty" width="1" height="1"/>
-    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="vVm-39-T7Z"/>
     </inferredMetricsTieBreakers>

--- a/iidaPro-2015/Main.storyboard
+++ b/iidaPro-2015/Main.storyboard
@@ -54,6 +54,23 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="EAn-PY-EQu">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <searchBar key="tableHeaderView" contentMode="redraw" id="251-F6-NKL">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                    <textInputTraits key="textInputTraits"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="Ecc-V6-wdr" id="xEk-ff-aTL"/>
+                                    </connections>
+                                </searchBar>
+                                <prototypes>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="7ga-4N-65h">
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7ga-4N-65h" id="3jS-vv-RSP">
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
                                 <connections>
                                     <outlet property="dataSource" destination="Ecc-V6-wdr" id="wAG-Tq-HNH"/>
                                     <outlet property="delegate" destination="Ecc-V6-wdr" id="mdJ-tv-cIL"/>
@@ -69,12 +86,13 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="searchBar" destination="251-F6-NKL" id="qG5-al-ykg"/>
                         <outlet property="searchTableView" destination="EAn-PY-EQu" id="jTB-WY-85M"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HaF-kv-4IJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1227" y="928"/>
+            <point key="canvasLocation" x="1227" y="932"/>
         </scene>
         <!--ごみの出し方-->
         <scene sceneID="d2g-xc-CEK">

--- a/iidaPro-2015/SearchResultViewController.h
+++ b/iidaPro-2015/SearchResultViewController.h
@@ -1,0 +1,16 @@
+//
+//  SearchResultViewController.h
+//  iidaPro-2015
+//
+//  Created by akaimo on 2015/08/11.
+//  Copyright (c) 2015年 akaimo. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SearchResultViewController : UIViewController
+
+@property (strong, nonatomic) NSMutableArray *resultArray;
+@property (strong, nonatomic) NSString *searchText;
+
+@end

--- a/iidaPro-2015/SearchResultViewController.m
+++ b/iidaPro-2015/SearchResultViewController.m
@@ -1,0 +1,69 @@
+//
+//  SearchResultViewController.m
+//  iidaPro-2015
+//
+//  Created by akaimo on 2015/08/11.
+//  Copyright (c) 2015年 akaimo. All rights reserved.
+//
+
+#import "SearchResultViewController.h"
+
+@interface SearchResultViewController () <UITableViewDelegate, UITableViewDataSource>
+@property (weak, nonatomic) IBOutlet UITableView *searchTableView;
+
+@end
+
+@implementation SearchResultViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    
+    self.title = _searchText;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [self.navigationController setNavigationBarHidden:NO animated:NO];
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+
+#pragma mark - UITableViewDataSource
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return _resultArray.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    // TODO: ゴミ分別マークとゴミの名前を表示
+    tableView.separatorColor = [UIColor clearColor];
+    static NSString *CellIdentifier = @"Cell";
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
+    
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
+    }
+    
+    cell.textLabel.text = [_resultArray[indexPath.row] valueForKey:@"name"];
+    
+    return cell;
+}
+
+#pragma mark - UITableViewDelegate
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    // TODO: 豆知識がある場合は豆知識ページへ遷移
+    NSLog(@"%ld", (long)indexPath.row);
+}
+
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // 画面遷移
+}
+
+@end

--- a/iidaPro-2015/SearchResultViewController.m
+++ b/iidaPro-2015/SearchResultViewController.m
@@ -8,8 +8,10 @@
 
 #import "SearchResultViewController.h"
 
-@interface SearchResultViewController () <UITableViewDelegate, UITableViewDataSource>
+@interface SearchResultViewController () <UITableViewDelegate, UITableViewDataSource, UISearchBarDelegate, UIScrollViewDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *searchTableView;
+@property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
+@property (retain, nonatomic) UIBarButtonItem *searchBtn;
 
 @end
 
@@ -19,7 +21,17 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view.
     
-    self.title = _searchText;
+    NSMutableString *searchTitle = [NSMutableString stringWithString:_searchText];
+    [searchTitle appendString:@"の検索結果"];
+    self.title = searchTitle;
+    
+    _searchBar.placeholder = @"Search";
+    _searchBar.text = _searchText;
+    
+    [_searchTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
+    
+    _searchBtn = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSearch target:self action:@selector(tapSearch:)];
+    self.navigationItem.rightBarButtonItem = _searchBtn;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -29,6 +41,39 @@
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+
+#pragma mark - searchBar
+- (void)searchBarSearchButtonClicked:(UISearchBar*)searchBar {
+    // TODO: 検索ワードから検索をかけ、辞書で返す
+    NSMutableArray *array = [NSMutableArray array];
+    for (int i=0; i<20; i++) {
+        NSMutableDictionary *dic = [NSMutableDictionary dictionary];
+        [dic setObject:@"hogehoge" forKey:@"name"];
+        [dic setObject:@"燃えるゴミ" forKey:@"trash"];
+        NSNumber *num = [NSNumber numberWithInt:i];
+        [dic setObject:num forKey:@"num"];
+        NSNumber *sepa = [NSNumber numberWithBool:NO];
+        [dic setObject:sepa forKey:@"separation"];
+        [array addObject:dic];
+    }
+    
+    // TODO: 検索結果を表示するためにtableViewを更新する
+    
+    [_searchBar resignFirstResponder];
+    [_searchTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:YES];
+}
+
+- (void)tapSearch:(UIButton *)sender {
+    [_searchBar becomeFirstResponder];
+    [_searchTableView setContentOffset:CGPointMake(0.0f, -64.0f) animated:YES];
+}
+
+
+#pragma mark - UIScrollViewDelegate
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
+    [_searchBar resignFirstResponder];
 }
 
 

--- a/iidaPro-2015/SearchResultViewController.m
+++ b/iidaPro-2015/SearchResultViewController.m
@@ -60,6 +60,12 @@
     }
     
     // TODO: 検索結果を表示するためにtableViewを更新する
+    NSMutableString *searchTitle = [NSMutableString stringWithString:_searchBar.text];
+    [searchTitle appendString:@"の検索結果"];
+    self.title = searchTitle;
+    
+    _resultArray = array;
+    [_searchTableView reloadData];
     
     [_searchBar resignFirstResponder];
     [_searchTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:YES];

--- a/iidaPro-2015/ViewController.m
+++ b/iidaPro-2015/ViewController.m
@@ -9,9 +9,9 @@
 #import "ViewController.h"
 #import "TipsTabViewController.h"
 
-@interface ViewController () <UITableViewDataSource, UITableViewDelegate>
-@property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
+@interface ViewController () <UISearchBarDelegate>
 
+@property (retain, nonatomic) UISearchBar *searchBar;
 @property (retain, nonatomic) UIImageView *trashView;
 @property (retain, nonatomic) UIScrollView *btnScrollView;
 
@@ -41,11 +41,15 @@ const CGFloat iconMargin = 20.0;
     
     // TODO: 端末情報から端末によりフォントサイズを調整
     
+    [self setupSearchBar];
     [self setBackgroundImage];
     [self setupTrashImage];
     [self setupDateLabel];
     [self setupEventLabel];
     [self setupScrollBar];
+    
+    UITapGestureRecognizer *tgr = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(singleTap:)];
+    [self.view addGestureRecognizer:tgr];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -55,6 +59,38 @@ const CGFloat iconMargin = 20.0;
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+
+#pragma mark - searchBar
+- (void)setupSearchBar {
+    _searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, 20, self.view.bounds.size.width, 44)];
+    _searchBar.delegate = self;
+    _searchBar.placeholder = @"Search";
+    _searchBar.backgroundImage = [UIImage imageNamed:@"empty"];
+    
+    [self.view addSubview:_searchBar];
+}
+
+// 検索(enter)したとき
+- (void)searchBarSearchButtonClicked:(UISearchBar*)searchBar {
+    [_searchBar resignFirstResponder];  // キーボードを閉じる
+}
+
+// キャンセルボタンがタップされたとき
+- (void)searchBarCancelButtonClicked:(UISearchBar*)searchBar {
+}
+
+// 値が変更されたとき
+- (void)searchBar:(UISearchBar*)searchBar textDidChange:(NSString*)searchText {
+}
+
+// テキスト入力を開始したとき
+- (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {
+}
+
+- (void)singleTap:(UITapGestureRecognizer *)sender {
+    [_searchBar resignFirstResponder];
 }
 
 
@@ -230,53 +266,6 @@ const CGFloat iconMargin = 20.0;
 // statusbarの色を白に
 - (UIStatusBarStyle)preferredStatusBarStyle {
     return UIStatusBarStyleLightContent;
-}
-
-
-
-#pragma mark - UITableViewDataSource
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 1;
-}
-
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    NSInteger count;
-    count = 10;
-    return count;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    tableView.separatorColor = [UIColor clearColor];
-    static NSString *CellIdentifier = @"Cell";
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
-    
-    if (!cell) {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
-    }
-    
-    cell.textLabel.text = @"hogehoge";
-    
-    return cell;
-}
-
-#pragma mark - UITableViewDelegate
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSLog(@"%ld", (long)indexPath.row);
-}
-
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // 画面遷移
-}
-
-
-#pragma mark - UISearchDisplayControllerDelegate
-- (BOOL)searchDisplayController:controller shouldReloadTableForSearchString:(NSString *)searchString {
-    [self filterContainsWithSearchText:searchString];
-    return YES;
-}
-
-- (void)filterContainsWithSearchText:(NSString *)searchText {
-    // searchTextをもとに検索する
 }
 
 @end

--- a/iidaPro-2015/ViewController.m
+++ b/iidaPro-2015/ViewController.m
@@ -8,6 +8,7 @@
 
 #import "ViewController.h"
 #import "TipsTabViewController.h"
+#import "SearchResultViewController.h"
 
 @interface ViewController () <UISearchBarDelegate>
 
@@ -74,6 +75,24 @@ const CGFloat iconMargin = 20.0;
 
 // 検索(enter)したとき
 - (void)searchBarSearchButtonClicked:(UISearchBar*)searchBar {
+    // TODO: 検索ワードから検索をかけ、辞書で返す
+    NSMutableArray *array = [NSMutableArray array];
+    for (int i=0; i<20; i++) {
+        NSMutableDictionary *dic = [NSMutableDictionary dictionary];
+        [dic setObject:@"hoge" forKey:@"name"];
+        [dic setObject:@"燃えるゴミ" forKey:@"trash"];
+        NSNumber *num = [NSNumber numberWithInt:i];
+        [dic setObject:num forKey:@"num"];
+        NSNumber *sepa = [NSNumber numberWithBool:NO];
+        [dic setObject:sepa forKey:@"separation"];
+        [array addObject:dic];
+    }
+    
+    SearchResultViewController *searchResultVC = [self.storyboard instantiateViewControllerWithIdentifier:@"Search"];
+    searchResultVC.resultArray = array;
+    searchResultVC.searchText = searchBar.text;
+    [self.navigationController pushViewController:searchResultVC animated:YES];
+    
     [_searchBar resignFirstResponder];  // キーボードを閉じる
 }
 


### PR DESCRIPTION
## searchController/shuhei
#### 8/12
- searchBarをタップしたらキーボードが表示される
- enterまたはキーボード以外をタップしたらキーボードが閉じる
- enterをタップしたら入力されているワードで検索するが、現在は辞書を生成しているだけ
- 検索が終わったら検索結果ページへ遷移する
- 検索結果ページでは、現在は上で生成した辞書が表示される（データの受け渡しができている）
- AutoLayoutのバグは確認されていない
##### 疑問点
- 検索結果画面での再検索できるようにするか
  - 再検索を可能にするなら検索結果画面にもsearchBarを設置する必要がある
  - 現在はnavigationBarのtitleに検索ワードを表示しているが、再検索が可能なら変更する必要がある
- 検索結果画面からトップに戻ったときにキーボードは表示させるか
  - 表示させる場合はenterを押したときに閉じる処理をなくすことになる
